### PR TITLE
Fix compilation issue due to new interrupt handling of KIT_XMC14_2GO

### DIFF
--- a/src/pas-co2-ino.cpp
+++ b/src/pas-co2-ino.cpp
@@ -367,7 +367,7 @@ Error_t PASCO2Ino::startMeasure(int16_t periodInSec, int16_t alarmTh, void (*cba
         }
 
         /* Enable mcu interupt */
-        attachInterrupt(digitalPinToInterrupt(intPin), (void (*)())cback, int_event);
+        attachInterrupt(digitalPinToInterrupt(intPin), (void (*)())cback, (PinStatus) int_event);
     }
     else
     {


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Due to changes to the attachment of the interrupt for the KIT_XMC14_2GO, the library for the PAS CO2 sensor does not properly compile anymore when used in combination. This is fixed by changing a single line of code to address the new enum for the status of the pin and its corresponding casting.

Related Issue
If you opened an issue before creating the PR, point to it here.

Context
I am running version 4.1.0 for the XMC board package, 3.2.1 for the PAS CO2 library and 3.2.8 for the Arduino IDE. I am using a KIT_XMC14_2GO as a target.